### PR TITLE
Set up CSV downloads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.3'
 gem 'simple_form'
+gem 'csv'
 #  gem 'bootstrap-sass', '~> 3.3.7'
 gem 'bootstrap', '~> 4.1.3'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,6 +683,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
+    csv (3.0.2)
     erubi (1.7.1)
     execjs (2.7.0)
     faker (1.9.1)
@@ -826,6 +827,7 @@ DEPENDENCIES
   carrierwave
   chromedriver-helper
   coffee-rails (~> 4.2)
+  csv
   faker
   jbuilder (~> 2.5)
   jquery-rails
@@ -850,4 +852,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/accept_grade_controller.rb
+++ b/app/controllers/accept_grade_controller.rb
@@ -6,13 +6,17 @@ class AcceptGradeController < ApplicationController
       submission = Submission.find(params[:id].to_i)
       if submission
         # TODO: Convert grade to int on frontend
-        submission.grade = ((params[:number_of_tests].to_f - (params[:number_of_failures].to_f + params[:number_of_errors].to_f)) / params[:number_of_tests]) * 100
+        tests_passed = params[:number_of_tests].to_f - (params[:number_of_failures].to_f + params[:number_of_errors].to_f)
+        total_tests = params[:number_of_tests]
+        submission.test_grade = (tests_passed / total_tests) * 100
+        submission.tests_passed = tests_passed
+        submission.total_tests = total_tests
         submission.save!
       end
     elsif status == "failure"
       submission = Submission.find(params[:id].to_i)
       if submission
-        submission.grade = 0
+        submission.test_grade = 0
         submission.save!
       end
     end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -2,7 +2,7 @@
 class AssignmentsController < ApplicationController
   include AssignmentsHelper
   include SessionsHelper
-  before_action :set_assignment, only: [:show, :edit, :update, :destroy, :grades]
+  before_action :set_assignment, only: [:show, :edit, :update, :destroy, :grades, :download_csv]
   before_action :require_login
 
   # GET /assignments
@@ -48,6 +48,17 @@ class AssignmentsController < ApplicationController
     Grade.find(params[:grade][:id]).update( ta_grade: params[:grade][:ta_grade].to_i)
     redirect_to assignment_grades_path
   end
+
+  def download_csv
+    @submissions = @assignment.submissions
+    respond_to do |format|
+      format.csv do
+        headers['Content-Disposition'] = "attachment; filename=\"AutoGrader_#{@assignment.name}.csv\""
+        headers['Content-Type'] ||= 'text/csv'
+      end
+    end
+  end
+
   # POST /assignments
   # POST /assignments.json
   def create

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -29,4 +29,30 @@ module AssignmentsHelper
     end
     grades.map &:save!
   end
+
+  def csv_lines
+    headers = ['Identifier', 'Full name', 'Email address', 'Status', 'Grade', 'Maximum Grade', 'Grade can be changed', 'Last modified (submission)', 'Last modified (grade)', 'Feedback comments']
+    lines = []
+    lines << headers
+    @submissions.each do |s|
+      curr_sub = []
+      curr_sub[0] = "Participant #{s.latte_id}"
+      curr_sub[1] = s.user.name
+      curr_sub[2] = s.user.email
+      curr_sub[4] = s.grade.final_grade
+      curr_sub[9] = "#{comment(s)}"
+      lines << curr_sub
+    end
+    lines
+  end
+
+  def comment(submission)
+    """TESTS PASSED: #{submission.tests_passed}
+    TOTAL TESTS: #{submission.total_tests}
+    TEST GRADE: #{submission.test_grade}
+    -----
+    TA GRADE: #{submission.grade.ta_grade}
+    GRADING TA: #{submission.grade.ta.name}
+    #{"-----\n#{submission.grade.custom_comment}" if submission.grade.custom_comment}"""
+  end
 end

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -13,4 +13,14 @@ class Grade < ApplicationRecord
   #
   # Grade where assignment is assignment id each
   # idea << map each student to a TA, rather than the other way around
+
+  def final_grade
+    test_weight = assignment.test_grade_weight.to_f / 100
+    test_grade_weighted = test_weight * submission.test_grade
+
+    ta_weight = 1 - test_weight
+    ta_grade_weighted = ta_weight * ta_grade
+
+    test_grade_weighted + ta_grade_weighted
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,5 @@
 class Submission < ApplicationRecord
   belongs_to :assignment
   belongs_to :user
+  belongs_to :grade
 end

--- a/app/views/assignments/download_csv.csv.erb
+++ b/app/views/assignments/download_csv.csv.erb
@@ -1,0 +1,3 @@
+<% csv_lines.each do |line| %>
+<%= CSV.generate_line(line).html_safe %>
+<% end %>

--- a/app/views/assignments/grades.html.erb
+++ b/app/views/assignments/grades.html.erb
@@ -1,4 +1,4 @@
-
+<%= button_to "Download CSV for LATTE", download_csv_assignments_path(id: @assignment.id, format: :csv), class: "btn btn-primary" %>
 <table class="table">
   <thead class = "thead-dark">
   <tr>
@@ -14,7 +14,7 @@
       <tr>
         <%= f.input :id, as: :hidden %>
         <td><%= grade.student.name %></td>
-        <td><%= grade.submission.grade if grade.submission %></td>
+        <td><%= grade.submission.test_grade if grade.submission %></td>
         <p></p>
         <td><%= f.input :ta_grade, label: false,  input_html: {value: grade.ta_grade,style: 'width: 100px', class:"form-control"} %></td>
         <td> <%= f.button :submit ,html_options= { class: "btn btn-primary", role: "button"}%></td>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <strong>Grade:</strong>
-  <%= @submission.grade %>
+  <%= @submission.test_grade %>
 </p>
 
 <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   resources :assignments do
     resources :submissions
+    collection do
+      post :download_csv
+    end
   end
   # resources :submissions
   resources :courses

--- a/db/migrate/20181224082816_add_latte_id_to_submissions.rb
+++ b/db/migrate/20181224082816_add_latte_id_to_submissions.rb
@@ -1,0 +1,9 @@
+class AddLatteIdToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :latte_id, :integer
+    add_index :submissions, :latte_id
+
+    add_column :submissions, :tests_passed, :integer
+    add_column :submissions, :total_tests, :integer
+  end
+end

--- a/db/migrate/20181224142711_add_test_grade_to_submissions.rb
+++ b/db/migrate/20181224142711_add_test_grade_to_submissions.rb
@@ -1,0 +1,10 @@
+class AddTestGradeToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :assignments, :test_grade_weight, :integer
+
+    remove_column :submissions, :grade
+    add_column :submissions, :test_grade, :decimal
+
+    add_column :grades, :custom_comment, :text
+  end
+end

--- a/db/migrate/20181224182705_remove_course_from_submissions.rb
+++ b/db/migrate/20181224182705_remove_course_from_submissions.rb
@@ -1,0 +1,8 @@
+class RemoveCourseFromSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :submissions, :course_id, :bigint
+    remove_column :submissions, :failures
+
+    remove_column :grades, :grade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_15_020328) do
+ActiveRecord::Schema.define(version: 2018_12_24_182705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2018_12_15_020328) do
     t.bigint "course_id"
     t.text "structure"
     t.text "description"
+    t.integer "test_grade_weight"
     t.index ["course_id"], name: "index_assignments_on_course_id"
   end
 
@@ -35,29 +36,30 @@ ActiveRecord::Schema.define(version: 2018_12_15_020328) do
   end
 
   create_table "grades", force: :cascade do |t|
-    t.decimal "grade"
     t.integer "ta_id"
     t.integer "student_id"
     t.integer "assignment_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "ta_grade"
+    t.text "custom_comment"
   end
 
   create_table "submissions", force: :cascade do |t|
-    t.decimal "grade"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "attachment"
     t.text "zip_uri"
-    t.bigint "course_id"
     t.bigint "user_id"
     t.bigint "assignment_id"
-    t.text "failures"
     t.bigint "grade_id"
+    t.integer "latte_id"
+    t.integer "tests_passed"
+    t.integer "total_tests"
+    t.decimal "test_grade"
     t.index ["assignment_id"], name: "index_submissions_on_assignment_id"
-    t.index ["course_id"], name: "index_submissions_on_course_id"
     t.index ["grade_id"], name: "index_submissions_on_grade_id"
+    t.index ["latte_id"], name: "index_submissions_on_latte_id"
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 


### PR DESCRIPTION
Added CSV downloads in LATTE-friendly format (assuming proper IDs), removed some unnecessary columns, and added backend for configurable test grade weights and TA comments.